### PR TITLE
completed Bronze layer

### DIFF
--- a/Other/LoadRawtoBronze.ipynb
+++ b/Other/LoadRawtoBronze.ipynb
@@ -1,0 +1,530 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d2a0234e-f271-4551-bec0-0dd1852de02f",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "checkpoint_path = '/Volumes/dev_catalog/bronze/checkpoint/'\n",
+    "LandingZone ='/Volumes/dev_catalog/bronze/landingzone'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "18afe82e-3aad-4692-bd9f-2f717899295f",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dbutils.widgets.text(name=\"env\",defaultValue=\"\",label=\" Enter the environment in lower case\")\n",
+    "env = dbutils.widgets.get(\"env\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "b21f2eef-7eab-42fb-8850-035603839112",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Read traffic data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "cd8cb86c-3b1f-48e3-885d-b0f6be934162",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def read_Traffic_Data():\n",
+    "    from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DoubleType\n",
+    "    from pyspark.sql.functions import current_timestamp\n",
+    "    print(\"Reading the Raw Traffic Data :  \", end='')\n",
+    "    schematraffic = StructType([\n",
+    "    StructField(\"Record_ID\",IntegerType()),\n",
+    "    StructField(\"Count_point_id\",IntegerType()),\n",
+    "    StructField(\"Direction_of_travel\",StringType()),\n",
+    "    StructField(\"Year\",IntegerType()),\n",
+    "    StructField(\"Count_date\",StringType()),\n",
+    "    StructField(\"hour\",IntegerType()),\n",
+    "    StructField(\"Region_id\",IntegerType()),\n",
+    "    StructField(\"Region_name\",StringType()),\n",
+    "    StructField(\"Local_authority_name\",StringType()),\n",
+    "    StructField(\"Road_name\",StringType()),\n",
+    "    StructField(\"Road_Category_ID\",IntegerType()),\n",
+    "    StructField(\"Start_junction_road_name\",StringType()),\n",
+    "    StructField(\"End_junction_road_name\",StringType()),\n",
+    "    StructField(\"Latitude\",DoubleType()),\n",
+    "    StructField(\"Longitude\",DoubleType()),\n",
+    "    StructField(\"Link_length_km\",DoubleType()),\n",
+    "    StructField(\"Pedal_cycles\",IntegerType()),\n",
+    "    StructField(\"Two_wheeled_motor_vehicles\",IntegerType()),\n",
+    "    StructField(\"Cars_and_taxis\",IntegerType()),\n",
+    "    StructField(\"Buses_and_coaches\",IntegerType()),\n",
+    "    StructField(\"LGV_Type\",IntegerType()),\n",
+    "    StructField(\"HGV_Type\",IntegerType()),\n",
+    "    StructField(\"EV_Car\",IntegerType()),\n",
+    "    StructField(\"EV_Bike\",IntegerType())\n",
+    "    ])\n",
+    "\n",
+    "\n",
+    "\n",
+    "    rawTraffic_stream = (spark.readStream\n",
+    "        .format(\"cloudFiles\")\n",
+    "        .option(\"cloudFiles.format\",\"csv\")\n",
+    "        .option(\"checkpointLocation\", f'{checkpoint_path}')\n",
+    "        .option('header','true')\n",
+    "        .schema(schematraffic)\n",
+    "        .load(f'{LandingZone}/raw_traffic/')\n",
+    "\n",
+    "        .withColumn(\"Extract_Time\", current_timestamp()))\n",
+    "    \n",
+    "    print('Reading Succcess !!')\n",
+    "    print('*******************')\n",
+    "\n",
+    "    return rawTraffic_stream"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "959cd689-f4db-450a-b58c-57a7c9e71050",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## write_Traffic_Data(StreamingDF,environment) Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "275d2631-7215-4258-9f73-27f47ac44124",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def write_Traffic_Data(StreamingDF,environment):\n",
+    "    print(f'Writing data to {environment}_catalog raw_traffic table', end='' )\n",
+    "    write_Stream = (StreamingDF.writeStream\n",
+    "                    .format('delta')\n",
+    "                    .option(\"checkpointLocation\",f'{checkpoint_path}/raw_traffic/')\n",
+    "                    .outputMode('append')\n",
+    "                    .queryName('rawTrafficWriteStream')\n",
+    "                    .trigger(availableNow=True)\n",
+    "                    .toTable(f\"`{environment}_catalog`.`bronze`.`raw_traffic`\"))\n",
+    "    \n",
+    "    write_Stream.awaitTermination()\n",
+    "    print('Write Success Traffic Data')\n",
+    "    print(\"****************************\")    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "3d3e1802-e713-40a2-a27e-35c3e46a49d5",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Create traffic data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "f0718970-ca47-4f98-aada-aa8d42230f49",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "read_DF = read_Traffic_Data()\n",
+    "write_Traffic_Data(read_DF,env)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "439852f9-5a0d-4a51-9f6a-c1676a867208",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "Creating write_Traffic_Data(StreamingDF,environment) Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "93effb93-8cfa-4c99-ab7f-00343988c39b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "read_DF = read_Traffic_Data()\n",
+    "write_Traffic_Data(read_DF,env)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ae1ef459-54d6-41c2-8815-07095d2b0dd3",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%sql\n",
+    "select count(*) from  dev_catalog.bronze.raw_traffic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "df492715-92ed-4734-b12d-ed7d2926d49d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Read road data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "8f6d9dbd-cfe5-4703-9767-a154beb39697",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def read_roads_data():\n",
+    "    from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DoubleType\n",
+    "    from pyspark.sql.functions import current_timestamp\n",
+    "    print(\"Reading the Raw Road Data :  \", end='')\n",
+    "    schemaroad = StructType([\n",
+    "        StructField(\"Road_ID\", IntegerType()),\n",
+    "        StructField(\"Road_Category_Id\", IntegerType()),\n",
+    "        StructField(\"Road_Category\", StringType()),\n",
+    "        StructField(\"Region_ID\", IntegerType()),\n",
+    "        StructField(\"Region_Name\", StringType()),\n",
+    "        StructField(\"Total_Link_Length_Km\", DoubleType()),\n",
+    "        StructField(\"Total_Link_Length_Miles\", DoubleType()),\n",
+    "        StructField(\"All_Motor_Vehicles\", DoubleType())\n",
+    "    ])\n",
+    "\n",
+    "\n",
+    "    # structureType\n",
+    "    rawroads_stream = (spark.readStream\n",
+    "        .format(\"cloudFiles\")\n",
+    "        .option(\"cloudFiles.format\",\"csv\")\n",
+    "        .option(\"checkpointLocation\", f'{checkpoint_path}/raw_roads/')\n",
+    "        .option('header','true')\n",
+    "        .schema(schemaroad)\n",
+    "        .load(f'{LandingZone}/raw_roads/')\n",
+    "\n",
+    "        .withColumn(\"Extract_Time\", current_timestamp()))\n",
+    "    \n",
+    "    print('Reading Succcess Road Data!')\n",
+    "    print('*******************')\n",
+    "\n",
+    "    return rawroads_stream"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "f08be084-f65b-40bb-a819-5113e5c12ad7",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## write_Road_Data(StreamingDF,environment) Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "dc62def0-3253-4f69-8421-716fe5dc4e2b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def write_Road_Data(StreamingDF,environment):\n",
+    "    print(f'Writing data to {environment}_catalog raw_road table', end='' )\n",
+    "    writeRoads_Stream = (StreamingDF.writeStream\n",
+    "                    .format('delta')\n",
+    "                    .option(\"checkpointLocation\",f'{checkpoint_path}/raw_roads/')\n",
+    "                    #.option(\"cloudFiles.partitionColumns\", \"Region_ID\")\n",
+    "                    .outputMode('append')\n",
+    "                    .queryName('rawroadsWriteStream')\n",
+    "                    .trigger(availableNow=True)\n",
+    "                    .toTable(f\"`{environment}_catalog`.`bronze`.`raw_roads`\"))\n",
+    "    \n",
+    "    writeRoads_Stream.awaitTermination()\n",
+    "    print('Write Success Road Data')\n",
+    "    print(\"****************************\")   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "85513fb8-694d-434d-99f5-b5f15843afee",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Create road data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "164d1f6b-09c4-4e7d-9c88-83c089ad537e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "read_road_DF = read_roads_data()\n",
+    "write_Road_Data(read_road_DF,env)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "90ad2e7c-80f2-4e48-ada9-702ff6e379a8",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%sql\n",
+    "select count(*) from dev_catalog.bronze.raw_roads"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": null,
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 7605022235638056,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "LoadRawtoBronze",
+   "widgets": {
+    "env": {
+     "currentValue": "dev",
+     "nuid": "4197a557-be1b-4817-b208-5eaba9d352d7",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": " Enter the environment in lower case",
+      "name": "env",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": " Enter the environment in lower case",
+      "name": "env",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": null,
+       "validationRegex": null
+      }
+     }
+    }
+   }
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/query sql.ipynb
+++ b/query sql.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "2d2dc93f-a578-40fc-b4c9-d7b06953600d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%sql\n",
+    "select * from dev_catalog.bronze.raw_traffic\n",
+    "order by Record_ID asc"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 7361971873879969,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "query sql",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
all good

## Summary by Sourcery

Implement the Bronze layer by introducing Databricks notebooks that read streaming CSV files for traffic and roads data from a landing zone, apply schemas and timestamps, and write them to environment-specific bronze Delta tables with checkpointing; also provide a SQL notebook for querying the ingested raw_traffic table.

New Features:
- Add LoadRawtoBronze notebook to stream raw traffic data from cloudFiles into bronze.raw_traffic Delta table with schema, checkpointing, and extract timestamp
- Add LoadRawtoBronze notebook to stream raw roads data from cloudFiles into bronze.raw_roads Delta table with schema, checkpointing, and extract timestamp
- Introduce widget-based environment parameterization and centralized checkpoint/landing zone paths in the Bronze ingestion notebook
- Add query sql notebook for inspecting the bronze.raw_traffic table