### PR TITLE
completed Silver

### DIFF
--- a/Other/LoadRawtoBronze.py
+++ b/Other/LoadRawtoBronze.py
@@ -142,6 +142,7 @@ def write_Road_Data(StreamingDF,environment):
                     #.option("cloudFiles.partitionColumns", "Region_ID")
                     .outputMode('append')
                     .queryName('rawroadsWriteStream')
+                    .option("mergeSchema", "true")
                     .trigger(availableNow=True)
                     .toTable(f"`{environment}_catalog`.`bronze`.`raw_roads`"))
     
@@ -158,6 +159,7 @@ def write_Road_Data(StreamingDF,environment):
 
 
 Initglobalvarpath(env)
+print(landingzone)
 read_DF = read_Traffic_Data()
 write_Traffic_Data(read_DF,env)
 read_road_DF = read_roads_data()

--- a/Other/common.py
+++ b/Other/common.py
@@ -46,6 +46,7 @@ def handle_NULLs(df,columns):
 
     print('Replacing NULL values on Numeric Columns with "0" ' , end='')
     df_clean = df_string.fillna(0,subset = columns)
+    print('*******************************************************')
     print('Success!! ')
 
     return df_clean
@@ -64,6 +65,7 @@ def create_TransformedTime(df):
     df_timestamp = df.withColumn('Transformed_Time',
                       current_timestamp()
                       )
+    print('*******************************************************')
     print('Success!!')
     return df_timestamp
 

--- a/Other/loadbronzetosilver.ipynb
+++ b/Other/loadbronzetosilver.ipynb
@@ -1,0 +1,550 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "9b627d8a-d509-44b1-83df-bad002360968",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%run \"/Workspace/Users/dbxdeschrtrial2@gmail.com/databricks/Other/common\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "5ff6c637-b05c-41b3-a213-6dcaebb5a8f3",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# read bonze roads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "9e10a9ea-3d40-4c74-a275-44d362987c25",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dbutils.widgets.text(name=\"env\",defaultValue=\"\",label=\" Enter the environment in lower case\")\n",
+    "global env\n",
+    "env = dbutils.widgets.get(\"env\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "b0d60511-a2c3-4e48-9fe6-44e6c5f4e486",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def read_BronzeRoadsTable(environment):\n",
+    "    print('Reading the Bronze Table raw_roads Data : ',end='')\n",
+    "    df_bronzeRoads = (spark.readStream\n",
+    "                    .table(f\"`{environment}_catalog`.`bronze`.raw_roads\")\n",
+    "                    )\n",
+    "    print(f'Reading {environment}_catalog.bronze.raw_roads Success!')\n",
+    "    print(\"**********************************\")\n",
+    "    return df_bronzeRoads"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "e0eda096-cb46-4284-a89e-47c68f08cf2a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# Create columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "be196ed6-29a2-4a8e-8944-9a399742f166",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Creating road_category_name column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "11ac7ff0-866e-48a1-86ee-90cebc65852b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def road_Category(df):\n",
+    "    print('Creating Road Category Name Column: ', end='')\n",
+    "    from pyspark.sql.functions import when,col\n",
+    "\n",
+    "    df_road_Cat = df.withColumn(\"Road_Category_Name\",\n",
+    "                  when(col('Road_Category') == 'TA', 'Class A Trunk Road')\n",
+    "                  .when(col('Road_Category') == 'TM', 'Class A Trunk Motor')\n",
+    "                   .when(col('Road_Category') == 'PA','Class A Principal road')\n",
+    "                    .when(col('Road_Category') == 'PM','Class A Principal Motorway')\n",
+    "                    .when(col('Road_Category') == 'M','Class B road')\n",
+    "                    .otherwise('NA')\n",
+    "                  \n",
+    "                  )\n",
+    "    print('Success!! ')\n",
+    "    print('***********************')\n",
+    "    return df_road_Cat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "3948621e-63ce-4405-8e3c-70ea0dc8c7ce",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## create roadCategory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "e1995479-a10c-4d66-8c40-ae358da2eec4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def roadCategory(df):\n",
+    "    print('create road category name: ',end='')\n",
+    "    from pyspark.sql.functions import col, when\n",
+    "    \n",
+    "    df_road_Cat = df.withColumn('Road_Category', \n",
+    "                       when(col('Road_Category') == 'TA', 'Class A Truck Road')\n",
+    "                       .when(col('Road_Category') == 'TM', 'Class A Truck Motor')\n",
+    "                       .when(col('Road_Category') == 'PA', 'Class A Principal Motorway')\n",
+    "                       .when(col('Road_Category') == 'M', 'Class B Road')\n",
+    "                       .otherwise('NA')\n",
+    "                      )\n",
+    "                      \n",
+    "    print('create road category name completed'\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "7e6bad84-ebd5-4eaa-a110-d3e05be79887",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## create road_type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "32f9dce4-c2d0-412e-a536-ad587d53152b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def roadtype(df):\n",
+    "    print('create road category name: ',end='')\n",
+    "    from pyspark.sql.functions import col, when\n",
+    "    \n",
+    "    df_road_Cat = df.withColumn('Road_Category', \n",
+    "                       when(col('Road_Category_name').like('%Class A%'), 'Major')\n",
+    "                       .when(col('Road_Category_name').like('%Class B%'), 'Minor')\n",
+    "                       .otherwise('NA')\n",
+    "                      )\n",
+    "                      \n",
+    "    print('create road type completed')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "704346fb-0ecb-4719-b89d-bf92f1476f43",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def handle_NULLs2(df,columns):\n",
+    "    print('Replacing NULL values on String Columns with \"Unknown\" ' , end='')\n",
+    "    df_string = df.fillna('Unknown',subset= columns)\n",
+    "    print('Successs!! ')\n",
+    "\n",
+    "    print('Replacing NULL values on Numeric Columns with \"0\" ' , end='')\n",
+    "    df_clean = df_string.fillna(0,subset = columns)\n",
+    "    print('*******************************************************')\n",
+    "    print('Success!! ')\n",
+    "\n",
+    "    return df_clean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "15b45036-0640-4775-825c-d31fdec7125e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Road_type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "76fb8a4a-424b-47f1-a591-2b3eb851a76f",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def road_Type(df):\n",
+    "    print('Creating Road Type Name Column: ', end='')\n",
+    "    from pyspark.sql.functions import when,col\n",
+    "\n",
+    "    df_road_Type = df.withColumn(\"Road_Type\",\n",
+    "                  when(col('Road_Category_Name').like('%Class A%'),'Major')\n",
+    "                  .when(col('Road_Category_Name').like('%Class B%'),'Minor')\n",
+    "                    .otherwise('NA')\n",
+    "                  \n",
+    "                  )\n",
+    "    print('Success!! ')\n",
+    "    print('***********************')\n",
+    "    return df_road_Type"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "61a5d40b-1cc0-42c8-abe1-163bafcb82aa",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# WRITE to silver.Silver_roads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "38d77be4-00be-4f50-b4b7-8ab0ea6c61c7",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def write_Roads_SilverTable(StreamingDF,environment):\n",
+    "    print('Writing the silver_roads Data : ',end='') \n",
+    "\n",
+    "    write_StreamSilver_R = (StreamingDF.writeStream\n",
+    "                .format('delta')\n",
+    "                .option(\"checkpointLocation\",f'{checkpoint_path}/SilverRoadsLoad/raw_roads/') \n",
+    "                .outputMode('append')\n",
+    "                .queryName(\"SilverRoadsWriteStream\")\n",
+    "                .trigger(availableNow=True)\n",
+    "                .toTable(f\"`{environment}_catalog`.`silver`.`silver_roads`\"))\n",
+    "    \n",
+    "    write_StreamSilver_R.awaitTermination()\n",
+    "    print(f'Writing `{environment}_catalog`.`silver`.`silver_roads` Success!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "8ee356e2-a98e-49fe-9ecd-c9ac066967e0",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# Main"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "58b81fc1-5732-443c-94fe-923e282b260a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Initglobalvarpath(env)\n",
+    "df_roads = read_BronzeRoadsTable(env)\n",
+    "df_noDups = remove_Dups(df_roads)\n",
+    "AllColumns = df_noDups.schema.names\n",
+    "df_clean = handle_NULLs(df_noDups,AllColumns)\n",
+    "## Creating Road_Category_name \n",
+    "df_roadCat = road_Category(df_clean)\n",
+    "\n",
+    "## Creating Road_Type column\n",
+    "df_type = road_Type(df_roadCat)\n",
+    "\n",
+    "## Writing data to silver_roads table\n",
+    "write_Roads_SilverTable(df_type,env)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "821938c7-da6a-4784-ac18-1e82ff322de9",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# query the silver table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "49d63b94-f711-4506-b1b5-0b5d78a9c791",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%sql\n",
+    "select * from dev_catalog.silver.silver_roads \n",
+    "where Road_Category_Name !='NA'\n",
+    "limit 100"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 7286027567524674,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "loadbronzetosilver",
+   "widgets": {
+    "env": {
+     "currentValue": "dev",
+     "nuid": "ae06e64c-fd0c-48c2-a06a-fea1c6ff949f",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": " Enter the environment in lower case",
+      "name": "env",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": " Enter the environment in lower case",
+      "name": "env",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": null,
+       "validationRegex": null
+      }
+     }
+    }
+   }
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary by Sourcery

Implement schema evolution support and complete the silver-layer load for road data by adding mergeSchema option, debug logging, and a new notebook that reads bronze data, transforms it, and writes to the silver_roads table.

New Features:
- Enable mergeSchema in the bronze writeStream to accommodate evolving road data schema
- Introduce a Databricks notebook to implement the end-to-end pipeline from bronze raw_roads to silver_roads (including deduplication, null handling, and road categorization)

Enhancements:
- Add debug print separators in common utility functions
- Log the landing zone path in the raw-to-bronze road loader