### PR TITLE
completed BronzetoSilver

### DIFF
--- a/Other/LoadRawtoBronze.py
+++ b/Other/LoadRawtoBronze.py
@@ -164,3 +164,8 @@ read_DF = read_Traffic_Data()
 write_Traffic_Data(read_DF,env)
 read_road_DF = read_roads_data()
 write_Road_Data(read_road_DF,env)
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC select count(*) from dev_catalog.bronze.raw_roads

--- a/Other/common.py
+++ b/Other/common.py
@@ -54,34 +54,18 @@ def handle_NULLs(df,columns):
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## -- Creating Transformed Time column
+# MAGIC ## -- Creating Time column
 # MAGIC
 
 # COMMAND ----------
 
-def create_TransformedTime(df):
+def create_columnTime(name,df):
     from pyspark.sql.functions import current_timestamp
-    print('Creating Transformed Time column : ',end='')
+    print('Creating {name} Time column : ',end='')
     df_timestamp = df.withColumn('Transformed_Time',
                       current_timestamp()
                       )
     print('*******************************************************')
-    print('Success!!')
-    return df_timestamp
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## -- Creating Extract_Time column
-
-# COMMAND ----------
-
-def create_Extract_Time(df):
-    from pyspark.sql.functions import current_timestamp
-    print('Creating Extract Time column : ',end='')
-    df_timestamp = df.withColumn('Extract_Time',
-                      current_timestamp()
-                      )
     print('Success!!')
     return df_timestamp
 

--- a/Other/loadroadsbronzetosilver.ipynb
+++ b/Other/loadroadsbronzetosilver.ipynb
@@ -25,10 +25,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "5ff6c637-b05c-41b3-a213-6dcaebb5a8f3",
      "showTitle": false,
@@ -105,17 +102,14 @@
     }
    },
    "source": [
-    "# Create columns"
+    "# Transformation create columns"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "be196ed6-29a2-4a8e-8944-9a399742f166",
      "showTitle": false,
@@ -167,10 +161,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "3948621e-63ce-4405-8e3c-70ea0dc8c7ce",
      "showTitle": false,
@@ -220,10 +211,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "7e6bad84-ebd5-4eaa-a110-d3e05be79887",
      "showTitle": false,
@@ -301,10 +289,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "15b45036-0640-4775-825c-d31fdec7125e",
      "showTitle": false,
@@ -402,10 +387,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "8ee356e2-a98e-49fe-9ecd-c9ac066967e0",
      "showTitle": false,
@@ -435,14 +417,21 @@
    },
    "outputs": [],
    "source": [
+    "# Initiate variable path\n",
     "Initglobalvarpath(env)\n",
+    "\n",
+    "# read Bronze Table\n",
     "df_roads = read_BronzeRoadsTable(env)\n",
+    "\n",
+    "# Transformation silver layer\n",
+    "# Cleaning Data\n",
     "df_noDups = remove_Dups(df_roads)\n",
     "AllColumns = df_noDups.schema.names\n",
     "df_clean = handle_NULLs(df_noDups,AllColumns)\n",
+    "\n",
+    "# Transformation silver layer\n",
     "## Creating Road_Category_name \n",
     "df_roadCat = road_Category(df_clean)\n",
-    "\n",
     "## Creating Road_Type column\n",
     "df_type = road_Type(df_roadCat)\n",
     "\n",
@@ -511,7 +500,7 @@
     },
     "pythonIndentUnit": 4
    },
-   "notebookName": "loadbronzetosilver",
+   "notebookName": "loadroadsbronzetosilver",
    "widgets": {
     "env": {
      "currentValue": "dev",

--- a/Other/loadtrafficbronzetosilver.ipynb
+++ b/Other/loadtrafficbronzetosilver.ipynb
@@ -1,0 +1,437 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "9b627d8a-d509-44b1-83df-bad002360968",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%run \"/Workspace/Users/dbxdeschrtrial2@gmail.com/databricks/Other/common\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ada2e205-894f-4b36-a6d0-1b23e095d684",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "a64b4dff-3485-44e8-900e-5c570f45a233",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "5ff6c637-b05c-41b3-a213-6dcaebb5a8f3",
+     "showTitle": true,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# read bonze traffic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "9e10a9ea-3d40-4c74-a275-44d362987c25",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dbutils.widgets.text(name=\"env\",defaultValue=\"\",label=\" Enter the environment in lower case\")\n",
+    "global env\n",
+    "env = dbutils.widgets.get(\"env\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "b0d60511-a2c3-4e48-9fe6-44e6c5f4e486",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def read_BronzetrafficTable(environment):\n",
+    "    print('Reading the Bronze Table raw_traffic Data : ',end='')\n",
+    "    df_bronzeRoads = (spark.readStream\n",
+    "                    .table(f\"`{environment}_catalog`.`bronze`.raw_traffic\")\n",
+    "                    )\n",
+    "    print(f'Reading {environment}_catalog.bronze.raw_traffic Success!')\n",
+    "    print(\"**********************************\")\n",
+    "    return df_bronzeRoads"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "e0eda096-cb46-4284-a89e-47c68f08cf2a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# Transformation create columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "1a3aea5e-7b0f-481d-b8b2-861af37eeb6b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# Creating columns total of electric vehicules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "f870f03a-4637-4a05-be5c-1ec8c758b35a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def traffic_Total_EV(df):\n",
+    "    print('Creating traffic Total EV : ', end='')\n",
+    "    from pyspark.sql.functions import when,col\n",
+    "\n",
+    "    df_traffic_Cat = df.withColumn(\"Total_EV\",\n",
+    "                                col('EV_car') +  col('EV_bike')\n",
+    "    )\n",
+    "    print(f'Creating traffic Total EV  Success!')\n",
+    "    return df_traffic_Cat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "e3bfe05f-a5fc-4a15-96b7-2446fd4b4cb5",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# Creating columns total all motor vehicules"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "61a5d40b-1cc0-42c8-abe1-163bafcb82aa",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# WRITE to silver.Silver_roads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "38d77be4-00be-4f50-b4b7-8ab0ea6c61c7",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def write_traffic_SilverTable(StreamingDF,environment):\n",
+    "    print('Writing the silver_traffic Data : ',end='') \n",
+    "\n",
+    "    write_TrafficStreamSilver_R = (StreamingDF.writeStream\n",
+    "                .format('delta')\n",
+    "                .option(\"checkpointLocation\",f'{checkpoint_path}SilvertrafficLoad/raw_traffic/') \n",
+    "                .outputMode('append')\n",
+    "                .queryName(\"SilverTrafficWriteStream\")\n",
+    "                .trigger(availableNow=True)\n",
+    "                .toTable(f\"`{environment}_catalog`.`silver`.`silver_traffic`\"))\n",
+    "    \n",
+    "    write_TrafficStreamSilver_R.awaitTermination()\n",
+    "    \n",
+    "    print(f'Writing `{environment}_catalog`.`silver`.`silver_traffic` Success!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "8ee356e2-a98e-49fe-9ecd-c9ac066967e0",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# Main"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "58b81fc1-5732-443c-94fe-923e282b260a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate variable path\n",
+    "Initglobalvarpath(env)\n",
+    "\n",
+    "# read Bronze Table\n",
+    "df_traffic = read_BronzetrafficTable(env)\n",
+    "\n",
+    "# Transformation silver layer\n",
+    "# Cleaning Data\n",
+    "df_noDups = remove_Dups(df_traffic)\n",
+    "AllColumns = df_noDups.schema.names\n",
+    "df_clean = handle_NULLs(df_noDups,AllColumns)\n",
+    "\n",
+    "# Transformation silver layer\n",
+    "df_traffic_Total_EV = traffic_Total_EV(df_clean)\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "## Writing data to silver_traffic table\n",
+    "write_traffic_SilverTable(df_traffic_Total_EV , env)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "821938c7-da6a-4784-ac18-1e82ff322de9",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# query the silver table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "49d63b94-f711-4506-b1b5-0b5d78a9c791",
+     "showTitle": false,
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1753300712701}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%sql\n",
+    "select * from dev_catalog.silver.silver_traffic\n",
+    "limit 100"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 1252899980927870,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "loadtrafficbronzetosilver",
+   "widgets": {
+    "env": {
+     "currentValue": "dev",
+     "nuid": "ae06e64c-fd0c-48c2-a06a-fea1c6ff949f",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": " Enter the environment in lower case",
+      "name": "env",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": " Enter the environment in lower case",
+      "name": "env",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": null,
+       "validationRegex": null
+      }
+     }
+    }
+   }
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary by Sourcery

Complete the bronze-to-silver ETL pipelines for both roads and traffic data, refresh notebook metadata and sectioning, and refactor common utilities for time column creation.

New Features:
- Implement roads bronze-to-silver pipeline in loadroadsbronzetosilver notebook
- Implement traffic bronze-to-silver pipeline in new loadtrafficbronzetosilver notebook

Enhancements:
- Clean up notebook metadata by resetting cellMetadata settings and refining section headers
- Refactor time column creation in common.py by renaming and parameterizing create_columnTime and removing duplicate function
- Add SQL validation query in LoadRawtoBronze.py to count records in the raw_roads bronze table