### PR TITLE
complete

### DIFF
--- a/Other/LoadRawtoBronze.py
+++ b/Other/LoadRawtoBronze.py
@@ -59,13 +59,15 @@ def read_Traffic_Data():
         .option('header','true')
         .schema(schematraffic)
         .load(f'{landingzone}/raw_traffic/')
+        )
 
-        .withColumn("Extract_Time", current_timestamp()))
+    ret_rawTraffic_stream = create_columnTime('Extract_Time',rawTraffic_stream)
+     
     
     print('Reading Succcess !!')
     print('*******************')
 
-    return rawTraffic_stream
+    return ret_rawTraffic_stream
 
 # COMMAND ----------
 
@@ -119,13 +121,14 @@ def read_roads_data():
         .option('header','true')
         .schema(schemaroad)
         .load(f'{landingzone}/raw_roads/')
-
-        .withColumn("Extract_Time", current_timestamp()))
+    )
+    ret_rawroads_stream = create_columnTime('Extract_Time',rawroads_stream)
+   
     
     print('Reading Succcess Road Data!')
     print('*******************')
 
-    return rawroads_stream
+    return ret_rawroads_stream
 
 # COMMAND ----------
 
@@ -160,10 +163,14 @@ def write_Road_Data(StreamingDF,environment):
 
 Initglobalvarpath(env)
 print(landingzone)
-read_DF = read_Traffic_Data()
-write_Traffic_Data(read_DF,env)
+read_Traffic_DF = read_Traffic_Data()
+clean_Traffic_df = clean_spark_cols(read_Traffic_DF,'Traffic')
+
+write_Traffic_Data(clean_Traffic_df ,env)
+
 read_road_DF = read_roads_data()
-write_Road_Data(read_road_DF,env)
+clean_road_Data_cols = clean_spark_cols(read_road_DF,'Road')
+write_Road_Data(clean_road_Data_cols,env)
 
 # COMMAND ----------
 

--- a/Other/common.py
+++ b/Other/common.py
@@ -61,8 +61,8 @@ def handle_NULLs(df,columns):
 
 def create_columnTime(name,df):
     from pyspark.sql.functions import current_timestamp
-    print('Creating {name} Time column : ',end='')
-    df_timestamp = df.withColumn('Transformed_Time',
+    print(f'Creating time column : {name} ',end='')
+    df_timestamp = df.withColumn('{name}',
                       current_timestamp()
                       )
     print('*******************************************************')
@@ -81,3 +81,18 @@ def remove_Dups(df):
     df_dup = df.dropDuplicates()
     print('Success!')
     return df_dup
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC # Create column names that are compatible with Delta tables.
+
+# COMMAND ----------
+
+def clean_spark_cols(df,name):
+    print(f'Cleaning Spark Columns table name: {name} ',end='')
+    for col in df.columns:
+        df = df.withColumnRenamed(col, col.replace(" ", "_"))
+    print('Success!! ')
+    return df
+

--- a/Other/loadroadsbronzetosilver.ipynb
+++ b/Other/loadroadsbronzetosilver.ipynb
@@ -25,7 +25,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "5ff6c637-b05c-41b3-a213-6dcaebb5a8f3",
      "showTitle": false,
@@ -93,7 +96,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "e0eda096-cb46-4284-a89e-47c68f08cf2a",
      "showTitle": false,
@@ -109,7 +115,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "be196ed6-29a2-4a8e-8944-9a399742f166",
      "showTitle": false,
@@ -161,7 +170,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "3948621e-63ce-4405-8e3c-70ea0dc8c7ce",
      "showTitle": false,
@@ -211,7 +223,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "7e6bad84-ebd5-4eaa-a110-d3e05be79887",
      "showTitle": false,
@@ -255,41 +270,13 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 0,
+   "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "inputWidgets": {},
-     "nuid": "704346fb-0ecb-4719-b89d-bf92f1476f43",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def handle_NULLs2(df,columns):\n",
-    "    print('Replacing NULL values on String Columns with \"Unknown\" ' , end='')\n",
-    "    df_string = df.fillna('Unknown',subset= columns)\n",
-    "    print('Successs!! ')\n",
-    "\n",
-    "    print('Replacing NULL values on Numeric Columns with \"0\" ' , end='')\n",
-    "    df_clean = df_string.fillna(0,subset = columns)\n",
-    "    print('*******************************************************')\n",
-    "    print('Success!! ')\n",
-    "\n",
-    "    return df_clean"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "15b45036-0640-4775-825c-d31fdec7125e",
      "showTitle": false,
@@ -338,7 +325,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "61a5d40b-1cc0-42c8-abe1-163bafcb82aa",
      "showTitle": false,
@@ -387,7 +377,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "8ee356e2-a98e-49fe-9ecd-c9ac066967e0",
      "showTitle": false,
@@ -443,7 +436,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "821938c7-da6a-4784-ac18-1e82ff322de9",
      "showTitle": false,


### PR DESCRIPTION
## Summary by Sourcery

Standardize notebook cell metadata, refactor and centralize timestamping logic, and introduce column-cleaning helper to streamline the raw-to-bronze data ingestion pipeline

New Features:
- Add clean_spark_cols utility to sanitize DataFrame column names
- Refine create_columnTime to accept dynamic column names and centralize timestamping

Enhancements:
- Refactor read_Traffic_Data and read_roads_data to use create_columnTime
- Integrate clean_spark_cols into the data ingestion flow before writing
- Remove obsolete handle_NULLs2 code block from notebook

Documentation:
- Apply consistent byteLimit and rowLimit metadata to all Databricks notebook markdown cells